### PR TITLE
fix: throw error when component lacks static schema

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -99,14 +99,9 @@ async function renderComponentWithValidation(
 ): Promise<string> {
   const schema = getSchema(type);
   if (!schema) {
-    context.errors.push({
-      component: componentName,
-      prop: null,
-      message: `Component "${componentName}" does not have a schema defined. All components must declare a static schema.`,
-      code: 'missing_schema',
-      path: [],
-    });
-    return renderChildrenFallback(children, context);
+    throw new Error(
+      `Component "${componentName}" does not have a schema defined. All components must declare a static schema.`,
+    );
   }
 
   const validationErrors = validateProps(componentName, { ...props, children }, schema);


### PR DESCRIPTION
## Summary
- Changed `renderComponentWithValidation` to throw an error instead of silently falling back when a component lacks a static schema
- Updated existing tests to expect the new throwing behavior
- Added regression test for issue #6

## Test plan
- [x] Verify components without schema throw a clear error message
- [x] Verify the error message includes the component name
- [x] All 834 tests pass

Closes #6